### PR TITLE
Upgrade versions of sbt and sbt-git

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ lazy val root = project
   .copy(id = "sbt-prompt")
   .in(file("."))
   .settings(
-    addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5"),
+    addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3"),
     libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.21"
   )
   .settings(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=0.13.15


### PR DESCRIPTION
Not really a big change in here, but removes an eviction warning when sbt-git and sbt-prompt are configured globally.