### PR TITLE
Add a generic Sbt Key promptlet and a current SBT version promptlet

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,22 @@ Renders the current scala version in the project. Example:
 currentScalaVersion(fg(red))
 ```
 
+#### Promptlet: ``currentSbtVersion(style)``
+Renders the current SBT version. Example:
+
+```scala
+currentSbtVersion(fg(26))
+```
+
+#### Promptlet: ``currentSbtKey(settingKey, style)``
+Renders the current value for the SBT key. Example:
+
+```scala
+currentSbtKey(version, fg(26))
+```
+
+That will generate a promptlet with the current version of the project. In fact, `currentScalaVersion` and `currentSbtVersion` are short-hands for `currentSbtKey(scalaVersion)` and `currentSbtKey(sbtVersion)`.
+
 #### Promplet: ``hostName(style)``
 Renders the current system hostname. Example:
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/src/main/scala/com/scalapenos/sbt/prompt/promptlets/promptlets.scala
+++ b/src/main/scala/com/scalapenos/sbt/prompt/promptlets/promptlets.scala
@@ -24,10 +24,16 @@ trait BasicPromptlets extends Styles {
   def userName(style: Style = NoStyle): Promptlet = text(_ ⇒ cachedUserName, style)
   def hostName(style: Style = NoStyle): Promptlet = text(_ ⇒ cachedHostName, style)
 
-  def currentScalaVersion(style: Style = NoStyle) = text(state ⇒ {
+  def currentSbtKey(settingKey: SettingKey[_], style: Style = NoStyle): Promptlet = text(state ⇒ {
     val extracted = Project.extract(state)
-    extracted.get(scalaVersion)
+    s"${extracted.get(settingKey)}"
   }, style)
+
+  def currentScalaVersion(style: Style = NoStyle) =
+    currentSbtKey(scalaVersion, style)
+
+  def currentSbtVersion(style: Style = NoStyle) =
+    currentSbtKey(sbtVersion, style)
 
   private lazy val cachedUserName = sys.props("user.name")
   private lazy val cachedHostName = java.net.InetAddress.getLocalHost().getHostName().stripSuffix(".local")


### PR DESCRIPTION
It also upgrades SBT to 0.13.16, which allows to cross build plugins between different SBT versions (i.e.: supporting the upcoming SBT 1.0.0)